### PR TITLE
Fix for commands that need to be CamelCased

### DIFF
--- a/sucks/__init__.py
+++ b/sucks/__init__.py
@@ -242,7 +242,7 @@ class VacBotCommand:
     def to_xml(self):
         ctl = ET.Element('ctl', {'td': self.name})
         if self.args:
-            inner = ET.Element(self.name, self.args)
+            inner = ET.Element(self.name.lower(), self.args)
             ctl.append(inner)
         return ctl
 

--- a/sucks/__init__.py
+++ b/sucks/__init__.py
@@ -194,6 +194,7 @@ class VacBot(ClientXMPP):
 
     def send_command(self, xml):
         c = self.wrap_command(xml)
+        logging.debug('Sending command {0}'.format(c))
         c.send()
 
     def wrap_command(self, ctl):
@@ -227,7 +228,7 @@ class VacBot(ClientXMPP):
 
 
 class VacBotCommand:
-    def __init__(self, name, args, wait=None, terminal=False):
+    def __init__(self, name, args=None, wait=None, terminal=False):
         self.name = name
         self.args = args
         self.wait = wait
@@ -239,9 +240,10 @@ class VacBotCommand:
             time.sleep(self.wait)
 
     def to_xml(self):
-        ctl = ET.Element('ctl', {'td': self.name.capitalize()})
-        inner = ET.Element(self.name, self.args)
-        ctl.append(inner)
+        ctl = ET.Element('ctl', {'td': self.name})
+        if self.args:
+            inner = ET.Element(self.name, self.args)
+            ctl.append(inner)
         return ctl
 
     def __str__(self, *args, **kwargs):
@@ -253,17 +255,17 @@ class VacBotCommand:
 
 class Clean(VacBotCommand):
     def __init__(self, wait):
-        super().__init__('clean', {'type': 'auto', 'speed': 'standard'}, wait)
+        super().__init__('Clean', {'type': 'auto', 'speed': 'standard'}, wait)
 
 
 class Edge(VacBotCommand):
     def __init__(self, wait):
-        super().__init__('clean', {'type': 'border', 'speed': 'strong'}, wait)
+        super().__init__('Clean', {'type': 'border', 'speed': 'strong'}, wait)
 
 
 class Charge(VacBotCommand):
     def __init__(self):
-        super().__init__('charge', {'type': 'go'}, terminal=True)
+        super().__init__('Charge', {'type': 'go'}, terminal=True)
 
     def wait_for_completion(self, bot):
         logging.debug("waiting in " + self.name)
@@ -275,7 +277,7 @@ class Charge(VacBotCommand):
 
 class Stop(VacBotCommand):
     def __init__(self):
-        super().__init__('clean', {'type': 'stop', 'speed': 'standard'}, terminal=True)
+        super().__init__('Clean', {'type': 'stop', 'speed': 'standard'}, terminal=True)
 
     def wait_for_completion(self, bot):
         logging.debug("waiting in " + self.name)

--- a/tests/test_vacbot.py
+++ b/tests/test_vacbot.py
@@ -10,6 +10,20 @@ from sucks import *
 # the library's design and its multithreaded nature, and b) I'm manually testing every change anyhow,
 # as it's not clear how the robot really behaves.
 
+def test_custom_command():
+    # Ensure a custom-built command generates the expected XML payload
+    c = VacBotCommand('CustomCommand', {'type': 'customtype'})
+    assert_equals(ElementTree.tostring(c.to_xml()),
+
+                  b'<ctl td="CustomCommand"><customcommand type="customtype" /></ctl>')
+
+def test_custom_command_noargs():
+    # Ensure a custom-built command with no args generates XML without an args element
+    c = VacBotCommand('CustomCommand')
+    assert_equals(ElementTree.tostring(c.to_xml()),
+                  b'<ctl td="CustomCommand" />')
+
+
 def test_clean_command():
     c = Clean(10)
     assert_equals(c.terminal, False)


### PR DESCRIPTION
The capitalization adjustment was breaking any commands that required CamelCase, such as GetChargeState. Now it won't muck with the capitalization, and the built-in Classes for Clean, Edge, etc now have the correct capitalization baked right in.

Args are not needed for commands such as GetChargeState, so the xml will no longer build that array if it's set to None (which is also now an optional param).