### PR TITLE
Storage of login response token, as well as a logout feature. 

### DIFF
--- a/sucks/__init__.py
+++ b/sucks/__init__.py
@@ -112,6 +112,30 @@ class EcoVacsAPI:
         })['devices']
         return devices
 
+	
+    @staticmethod
+    def logout_user(user_continent, args): 
+        
+        params = {'todo': 'logout'}
+        params.update(args)
+        
+        logging.debug("logging out user {} with data {}".format(params['userId'], params))
+        response = requests.post(EcoVacsAPI.USER_URL_FORMAT.format(continent=user_continent.upper()), json=params)
+
+        json = response.json()
+        logging.debug("got {}".format(json))
+        
+        if json['result'] == 'ok':
+            return json
+        elif json['errno'] == 1013:
+            logging.warning("token error on logout response, might already be logged out?")
+            return json
+        else:
+            logging.error("call to {} failed with {}".format('logout', json))
+            raise RuntimeError(
+                "failure {} ({}) for call {} and parameters {}".format(json['error'], json['errno'], 'logout', params))
+		
+		
     @staticmethod
     def md5(text):
         return hashlib.md5(bytes(str(text), 'utf8')).hexdigest()


### PR DESCRIPTION
What do you think of this? I wanted to make us store the token/resource that's returned from a successful login and reuse it for any future commands, which eliminates some small unnecessary http requests, as well as potentially alleviating some security concerns (?) 

By doing this I've also created a quick logout command for CLI that "logs out" the token and deletes it from Ecovac's database, preventing further usage to that token. This does NOT log out any other device, or token. 

Last thing I added to this was an expiry length feature that'll cause the token to "refresh" itself automatically when needed before processing a command, seamlessly. (It just does this by logging out and back in quickly, I don't know if Ecovac's API has a feature for this yet.) This is just useful to control the token's lifespan on our own time instead, and could be more useful in the future. 

When the user logs in they have a new optional argument: -e (integer) or --expiry (integer)
that allows them to set how long (in hours) this token should live for before automatically refreshing itself. By default it's set to refresh itself every 168 hours. (1 Week, default could be set longer, up to you @wpietri)

Anyway, 
I haven't worked on this project in a short while (finals), but before I stopped I was working on this snippet of code and stored a login token way back then. That was almost a month ago? 
That token still works today, even after new login instances! This makes me wonder how many tokens I have out there in the wild that are ancient but still allow remote control to my deebot since I was working on this project, constantly logging in, and generating a lot of new ones. Heh. A little concerning I guess, which is why I wanted to pull this. 

I mentioned this in my commits but I'll look into setting up a proper login class that'll allow you to check your login status/log out/log in/token life/etc if we're interested! 
