### PR TITLE
Const and logging cleanup, addition of is_cleaning and is_charging

### DIFF
--- a/sucks/cli.py
+++ b/sucks/cli.py
@@ -10,6 +10,8 @@ from pycountry_convert import country_alpha2_to_continent_code
 
 from sucks import *
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class FrequencyParamType(click.ParamType):
     name = 'frequency'
@@ -66,11 +68,11 @@ class StatusWait(BotWait):
     def wait(self, bot):
         if not hasattr(bot, self.wait_on):
             raise ValueError("object " + bot + " does not have method " + self.wait_on)
-        logging.debug("waiting on " + self.wait_on + " for value " + self.wait_for)
+        _LOGGER.debug("waiting on " + self.wait_on + " for value " + self.wait_for)
 
         while getattr(bot, self.wait_on) != self.wait_for:
             time.sleep(0.5)
-        logging.debug("wait complete; " + self.wait_on + " is now " + self.wait_for)
+        _LOGGER.debug("wait complete; " + self.wait_on + " is now " + self.wait_for)
 
 
 class CliAction:
@@ -122,15 +124,15 @@ def should_run(frequency):
         return True
     n = random.random()
     result = n <= frequency
-    logging.debug("tossing coin: {:0.3f} <= {:0.3f}: {}".format(n, frequency, result))
+    _LOGGER.debug("tossing coin: {:0.3f} <= {:0.3f}: {}".format(n, frequency, result))
     return result
 
 
 @click.group(chain=True)
 @click.option('--debug/--no-debug', default=False)
 def cli(debug):
-    level = logging.DEBUG if debug else logging.ERROR
-    logging.basicConfig(level=level, format='%(levelname)-8s %(message)s')
+    logging.basicConfig(format='%(name)-10s %(levelname)-8s %(message)s')
+    _LOGGER.parent.setLevel(logging.DEBUG if debug else logging.ERROR)
 
 
 @cli.command(help='logs in with specified email; run this first')
@@ -202,7 +204,7 @@ def run(actions, debug):
         exit(1)
 
     if debug:
-        logging.debug("will run {}".format(actions))
+        _LOGGER.debug("will run {}".format(actions))
 
     if actions:
         config = read_config()

--- a/tests/test_vacbot.py
+++ b/tests/test_vacbot.py
@@ -95,6 +95,40 @@ def test_lifespan_reports():
     v._handle_ctl({'event': 'life_span', 'type': 'a_weird_component', 'total': '100', 'val': '87'})
     assert_equals({'side_brush': 0, 'main_brush': 0.005, 'a_weird_component': 0.87}, v.components)
 
+def test_is_cleaning():
+    v = a_vacbot()
+
+    assert_false(v.is_cleaning)
+
+    v._handle_ctl({'event': 'clean_report', 'type': 'auto', 'speed': 'strong'})
+    assert_true(v.is_cleaning)
+
+    v._handle_ctl({'event': 'clean_report', 'type': 'stop'})
+    assert_false(v.is_cleaning)
+
+    v._handle_ctl({'event': 'clean_report', 'type': 'edge', 'speed': 'normal'})
+    assert_true(v.is_cleaning)
+
+    v._handle_ctl({'event': 'charge_state', 'type': 'going'})
+    assert_false(v.is_cleaning)
+
+def test_is_charging():
+    v = a_vacbot()
+
+    assert_false(v.is_charging)
+
+    v._handle_ctl({'event': 'clean_report', 'type': 'auto', 'speed': 'strong'})
+    assert_false(v.is_charging)
+
+    v._handle_ctl({'event': 'charge_state', 'type': 'going'})
+    assert_false(v.is_charging)
+
+    v._handle_ctl({'event': 'charge_state', 'type': 'slot_charging'})
+    assert_true(v.is_charging)
+
+    v._handle_ctl({'event': 'clean_report', 'type': 'edge', 'speed': 'normal'})
+    assert_false(v.is_charging)
+
 def test_send_ping_no_monitor():
     v = a_vacbot()
 


### PR DESCRIPTION
In doing code reviews for Home Assistant support using sucks, a couple good points came up about moving some functionality to the library.

1. All sucks vocabulary is now defined up-front in consts, so that library users can import those consts instead of hard-coding them. If we ever need to change them, it should make (properly-implemented) consuming code much easier to update, if needed.

2. is_cleaning and is_charging properties were added to VacBot, avoiding library users to have to understand which vacuum statuses mean active cleaning. Two new const sets are used to keep track of which statuses represent these two broader states. Tests were added for these two new properties.

3. All logging has been moved to instantiated loggers using the module's namespace, as is recommended by the Python docs. (This allows, for example, users of Home Assistant to turn on sucks debug logging via a config file)